### PR TITLE
added display_url and logo_url

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -10,6 +10,9 @@ publish_mode: editorial_workflow
 media_folder: "public/images/uploads"
 public_folder: "/images/uploads"
 
+display_url: https://optimistic-hamilton-9b7da5.netlify.app/
+logo_url: https://cdn.freebiesupply.com/logos/large/2x/canada-4-logo-svg-vector.svg
+
 i18n:
   structure: multiple_folders
   locales: [en, fr]


### PR DESCRIPTION
Added display url which shows up in the top right corner of the CMS, so user can easily navigate back to the home page.
Also added logo_url which SHOULD replace the stock image on the CMS login page, but doesn't seem to be doing anything at this point in time.